### PR TITLE
doc: add defproc for 'term-size'

### DIFF
--- a/macro-debugger/macro-debugger/macro-debugger.scrbl
+++ b/macro-debugger/macro-debugger/macro-debugger.scrbl
@@ -601,6 +601,8 @@ module path and the module paths of its immediate dependents.
 
 @section-index["raco macro-profiler"]
 
+@defmodule[macro-debugger/analysis/profile]
+
 The Macro Profiler shows what macros contribute most to the
 @emph{expanded code size} of programs. Use the Macro Profiler when
 your program has compiled files that are larger than expected. (The
@@ -656,5 +658,7 @@ used in the macro's result. Macros that violate this assumption will
 have correspondingly incorrect profile costs.}
 
 ]
+
+@defproc[(term-size [stx any/c]) exact-nonnegative-integer?]{}
 
 @close-eval[the-eval]


### PR DESCRIPTION
The other day, I changed a macro to use a smaller template and wanted to write a regression test. Something like "the size of expanded code should be less than `50 * num-calls-to-my-macro`".

I ended up writing my own term-size function for the test.

But since this `term-size` helper is already public and probably does a better job, it seems worthwhile to index it.