### PR TITLE
Address error encountered in sandboxed evaluator

### DIFF
--- a/macro-debugger/macro-debugger/emit.rkt
+++ b/macro-debugger/macro-debugger/emit.rkt
@@ -2,7 +2,8 @@
 (require racket/contract/base)
 
 (define syntax-local-expand-observer
-  (dynamic-require ''#%expobs 'syntax-local-expand-observer))
+  (lambda ()
+    ((dynamic-require ''#%expobs 'syntax-local-expand-observer))))
 
 (define (emit-remark #:unmark? [unmark? (syntax-transforming?)] . args)
   (let ([observe (syntax-local-expand-observer)])


### PR DESCRIPTION
Eta-expand `dynamic-require` as discussed in #45.

I verified that this causes the error to go away when building docs locally.
