### PR TITLE
Handle resolved modules represented as symbols.

### DIFF
--- a/macro-debugger/tests/macro-debugger/tests/collects.rkt
+++ b/macro-debugger/tests/macro-debugger/tests/collects.rkt
@@ -58,10 +58,12 @@
 (define (rel+mod->mod rel mod)
   (let* ([rel (resolved-module-path-name rel)]
          [rel (if (pair? rel) (car rel) rel)])
-    (if (pair? mod)
-        #f  ;; give up on submodules for now; FIXME
-        (let-values ([(base file dir?) (split-path rel)])
-          (path->mod (simplify-path (build-path base mod)))))))
+    (cond
+      [(pair? mod) #f]  ;; give up on submodules for now; FIXME
+      [(not (path? rel)) #f]  ;; give up on non-path modules (e.g., lazy-require proxies)
+      [else
+       (let-values ([(base file dir?) (split-path rel)])
+         (path->mod (simplify-path (build-path base mod))))])))
 
 (define (path->mod path)
   (cond [(for/or ([c (current-library-collection-paths)]) (path->mod* path c))


### PR DESCRIPTION
Discovered while working on racket/typed-racket#1473.